### PR TITLE
Fix 2s not properly being positioned when being capped by the max size.

### DIFF
--- a/src/mosaic.rs
+++ b/src/mosaic.rs
@@ -66,7 +66,7 @@ pub fn mosaic(mut images: VecDeque<RgbImage>) -> RgbImage {
             );
             image::imageops::overlay(
                 &mut background, &second,
-                (size.first_width + SPACING_SIZE) as i64, 0,
+                (first.width() + SPACING_SIZE) as i64, 0,
             );
             background
         }


### PR DESCRIPTION
This fixes an issue where 2s were not positioned correctly when they were capped and resized by the max size of 4000.
Before:
![image](https://user-images.githubusercontent.com/32272859/184462937-8cae298f-927a-4aa4-a09e-8e8e8bef5e07.png)
After:
![image](https://user-images.githubusercontent.com/32272859/184462946-c73cc505-c816-4f5a-ab40-42670fd6ad9b.png)
