### PR TITLE
fix: update Dockerfile to build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,13 @@
-FROM rust:1.72 as builder
+FROM rust:alpine3.22 as builder
 WORKDIR /usr/src/mosaic
+
+# Install build dependencies for musl libc (what Alpine uses)
+RUN apk add --no-cache musl-dev
+
 COPY . .
 RUN cargo install --path .
 
-FROM alpine:latest
+FROM alpine:3.22
 COPY --from=builder /usr/local/cargo/bin/mosaic /usr/local/bin/mosaic
 
 CMD ["mosaic"]


### PR DESCRIPTION
Currently the docker file doesn't build due to outdated Rust. Plus the default Rust image isn't alpine so it doesn't build with the correct linker. 